### PR TITLE
Add arm64 as valid option

### DIFF
--- a/bin/kz
+++ b/bin/kz
@@ -43,7 +43,7 @@ platform() {
   local arch="unexpected_arch"
   case "$(uname -m)" in
   x86_64) arch=amd64 ;;
-  aarch64 | armv8l) arch=arm64 ;;
+  arm64 | aarch64 | armv8l) arch=arm64 ;;
   esac
 
   [ -n "$KZ_ARCH" ] && arch="$KZ_ARCH"


### PR DESCRIPTION
in my machine, `uname -m` evaluates to `arm64`
so let kz script recognize `arm64` as a valid input to make installation succeed.